### PR TITLE
Update Nancy to 0.0.33

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,19 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:alpine as nancy-builder
-
-RUN apk add --no-cache git && \
-    git clone https://github.com/sonatype-nexus-community/nancy && \
-    cd nancy && \
-    go build -o /usr/local/nancy
-
 FROM alpine:3.8
 
 LABEL com.github.actions.name="Nancy for GitHub Actions" \
     com.github.actions.description="Run Sonatype Nancy as part of your GitHub Actions workflow."
 
-COPY --from=nancy-builder /usr/local/nancy /usr/local/nancy
+RUN apk add --no-cache curl && \
+    mkdir -p /usr/local/ && \
+    curl -L -o /usr/local/nancy \
+        https://github.com/sonatype-nexus-community/nancy/releases/download/v0.0.33/nancy-linux.amd64-v0.0.33 && \
+    chmod +x /usr/local/nancy
 
 COPY entrypoint.sh /entrypoint.sh
 


### PR DESCRIPTION
Update the newest version of Nancy. This should not require a recompilation of nancy on Alpine anymore.

Tested: https://github.com/whyjustin/yet-another-vulnerable-golang-app/runs/284092084#step:4:0