### PR TITLE
Update action to use Nancy v1.0.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,6 @@ LABEL com.github.actions.name="Nancy for GitHub Actions" \
 #        https://github.com/sonatype-nexus-community/nancy/releases/download/v1.0.0/nancy-linux.amd64-v1.0.0 && \
 #    chmod +x /usr/local/nancy
 
-COPY entrypoint.sh /entrypoint.sh
-
-ENTRYPOINT ["/entrypoint.sh"]
+#COPY entrypoint.sh /entrypoint.sh
+#
+#ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,17 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.14-alpine
-#FROM sonatypecommunity/nancy:latest
+FROM alpine:3.12
 
 LABEL com.github.actions.name="Nancy for GitHub Actions" \
     com.github.actions.description="Run Sonatype Nancy as part of your GitHub Actions workflow."
 
-#RUN apk add --no-cache curl && \
-#    mkdir -p /usr/local/ && \
-#    curl -L -o /usr/local/nancy \
-#        https://github.com/sonatype-nexus-community/nancy/releases/download/v1.0.0/nancy-linux.amd64-v1.0.0 && \
-#    chmod +x /usr/local/nancy
 RUN apk add --no-cache curl && \
     curl -L -o nancy.apk \
         https://github.com/sonatype-nexus-community/nancy/releases/download/v1.0.0/nancy_1.0.0_linux_386.apk && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,16 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.14-alpine
+#FROM golang:1.14-alpine
+FROM sonatypecommunity/nancy:latest
 
 LABEL com.github.actions.name="Nancy for GitHub Actions" \
     com.github.actions.description="Run Sonatype Nancy as part of your GitHub Actions workflow."
 
-RUN apk add --no-cache curl && \
-    mkdir -p /usr/local/ && \
-    curl -L -o /usr/local/nancy \
-        https://github.com/sonatype-nexus-community/nancy/releases/download/v1.0.0/nancy-linux.amd64-v1.0.0 && \
-    chmod +x /usr/local/nancy
+#RUN apk add --no-cache curl && \
+#    mkdir -p /usr/local/ && \
+#    curl -L -o /usr/local/nancy \
+#        https://github.com/sonatype-nexus-community/nancy/releases/download/v1.0.0/nancy-linux.amd64-v1.0.0 && \
+#    chmod +x /usr/local/nancy
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ LABEL com.github.actions.name="Nancy for GitHub Actions" \
 RUN apk add --no-cache curl && \
     mkdir -p /usr/local/ && \
     curl -L -o /usr/local/nancy \
-        https://github.com/sonatype-nexus-community/nancy/releases/download/v0.3.1/nancy-linux.amd64-v0.3.1 && \
+        https://github.com/sonatype-nexus-community/nancy/releases/download/v1.0.0/nancy-linux.amd64-v1.0.0 && \
     chmod +x /usr/local/nancy
 
 COPY entrypoint.sh /entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,4 +30,4 @@ RUN apk add --no-cache curl && \
 
 COPY entrypoint.sh /entrypoint.sh
 
-#ENTRYPOINT ["/entrypoint.sh"]
+ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,4 +30,4 @@ RUN apk add --no-cache curl && \
 
 COPY entrypoint.sh /entrypoint.sh
 
-ENTRYPOINT ["/entrypoint.sh"]
+#ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:3.8
+FROM golang:1.14-alpine
 
 LABEL com.github.actions.name="Nancy for GitHub Actions" \
     com.github.actions.description="Run Sonatype Nancy as part of your GitHub Actions workflow."

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#FROM golang:1.14-alpine
-FROM sonatypecommunity/nancy:latest
+FROM golang:1.14-alpine
+#FROM sonatypecommunity/nancy:latest
 
 LABEL com.github.actions.name="Nancy for GitHub Actions" \
     com.github.actions.description="Run Sonatype Nancy as part of your GitHub Actions workflow."

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,10 @@ LABEL com.github.actions.name="Nancy for GitHub Actions" \
 #    curl -L -o /usr/local/nancy \
 #        https://github.com/sonatype-nexus-community/nancy/releases/download/v1.0.0/nancy-linux.amd64-v1.0.0 && \
 #    chmod +x /usr/local/nancy
+RUN apk add --no-cache curl && \
+    curl -L -o nancy.apk \
+        https://github.com/sonatype-nexus-community/nancy/releases/download/v1.0.0/nancy_1.0.0_linux_386.apk && \
+    apk add --no-cache --allow-untrusted nancy.apk
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,6 @@ LABEL com.github.actions.name="Nancy for GitHub Actions" \
 #        https://github.com/sonatype-nexus-community/nancy/releases/download/v1.0.0/nancy-linux.amd64-v1.0.0 && \
 #    chmod +x /usr/local/nancy
 
-#COPY entrypoint.sh /entrypoint.sh
-#
-#ENTRYPOINT ["/entrypoint.sh"]
+COPY entrypoint.sh /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -16,19 +16,21 @@ Run [Sonatype Nancy](https://github.com/sonatype-nexus-community/nancy) as part 
 
 **Default** : `go.list`. 
 
-This is the path to a file containing the output of the `go list` command.
+The path to a file containing the output of the `go list` command.
 The `go.list` file can be created with a command like: `go list -json -m all > go.list`
 
 ### `nancyCommand`
 
 **Default** : `sleuth` 
 
-You can replace this command with over commands recognized by `nancy`. e.g. `sleuth --loud`
+You can customize this input with other commands and flags recognized by `nancy`. 
+ 
+For example: `sleuth --loud`
 
 ## Example Usage
 
-The example below only requires `go` be installed in order to generate the `go.list` file. You could
-instead have some other part of the CI build generate that file for use by `nancy`.
+The example below only requires `go` be installed in order to generate the `go.list` file. 
+You could instead have some other part of the CI build generate that file for use by `nancy`.
 ```
 name: Go Nancy
 

--- a/README.md
+++ b/README.md
@@ -12,12 +12,23 @@ Run [Sonatype Nancy](https://github.com/sonatype-nexus-community/nancy) as part 
 
 ## Inputs
 
-### `target`
+### `goListFile`
 
-**Required** This is the path to the go.sum or Gopkg.lock file.
+**Default** : `go.list`. 
+
+This is the path to a file containing the output of the `go list` command.
+The `go.list` file can be created with a command like: `go list -json -m all > go.list`
+
+### `nancyCommand`
+
+**Default** : `sleuth` 
+
+You can replace this command with over commands recognized by `nancy`. e.g. `sleuth --loud`
 
 ## Example Usage
 
+The example below only requires `go` be installed in order to generate the `go.list` file. You could
+instead have some other part of the CI build generate that file for use by `nancy`.
 ```
 name: Go Nancy
 
@@ -25,15 +36,20 @@ on: [push]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v1
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v2
+
+    - name: Set up Go 1.x in order to write go.list file
+      uses: actions/setup-go@v2
+      with:
+        go-version: ^1.13
+    - name: WriteGoList
+      run: go list -json -m all > go.list
+
     - name: Nancy
       uses: sonatype-nexus-community/nancy-github-action@master
-      with:
-        target: go.sum
 ```
 
 ## Development
@@ -67,12 +83,6 @@ jobs:
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
-
-    - name: Build
-      run: go build -v .
-
-    - name: Test
-      run: go test -v .
 
     - name: WriteGoList
       run: go list -json -m all > go.list

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ jobs:
         nancyCommand: sleuth --loud
 ```
  
-  * Gotchya - As of go v1.15, there is an issue using `act` related to how docker handles http `indentity`
+  * Gotchya - As of go v1.15, there is an issue using `act` related to how docker handles http `identity`
   connections. Due to this issue, I had to run `act` in a Linux Virtual Machine when running go 1.15. The error 
   you see running `act` resulting from this issue looks similar to this:
     ```

--- a/README.md
+++ b/README.md
@@ -36,6 +36,64 @@ jobs:
         target: go.sum
 ```
 
+## Development
+
+There are probably better ways, but I found it useful to leverage the [act](https://github.com/nektos/act) project while developing
+this github action. This project allows you to push a branch to the github action repo, and use a commit hash to test the behavior
+of that branch. For example, a test project that uses the `nancy-github-action` could have the following `.github/workflows/go.yml` file. 
+Notice the commit hash `950a8965cd37d8e14aaa6aebd6c0d71b4da71fa3` used below in the `Scan` step to run the 
+development branch. 
+
+```
+name: Go
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+    - name: Set up Go 1.x
+      uses: actions/setup-go@v2
+      with:
+        go-version: ^1.13
+      id: go
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v2
+
+    - name: Build
+      run: go build -v .
+
+    - name: Test
+      run: go test -v .
+
+    - name: WriteGoList
+      run: go list -json -m all > go.list
+
+    - name: Scan
+      uses: sonatype-nexus-community/nancy-github-action@950a8965cd37d8e14aaa6aebd6c0d71b4da71fa3
+      with:
+        nancyCommand: sleuth --loud
+```
+ 
+  * Gotchya - As of go v1.15, there is an issue using `act` related to how docker handles http `indentity`
+  connections. Due to this issue, I had to run `act` in a Linux Virtual Machine when running go 1.15. The error 
+  you see running `act` resulting from this issue looks similar to this:
+    ```
+    $ act 
+    [Go/Build] 🚀  Start image=node:12.6-buster-slim
+    [Go/Build]   🐳  docker run image=node:12.6-buster-slim entrypoint=["/usr/bin/tail" "-f" "/dev/null"] cmd=[]
+    [Go/Build]   🐳  docker cp src=/Users/bhamail/sonatype/community/go/gh-action-test/. dst=/github/workspace
+    Error: error during connect: Post "http://%2Fvar%2Frun%2Fdocker.sock/v1.40/exec/9f2eb3f2ea59b7e41c32efe56a90c2919fe4b459b3f1e763dd02686f797839da/start": net/http: HTTP/1.x transport connection broken: unsupported transfer encoding: "identity"
+    ```
+
 ## The Fine Print
 
 It is worth noting that this is **NOT SUPPORTED** by Sonatype, and is a contribution of ours

--- a/action.yml
+++ b/action.yml
@@ -4,7 +4,8 @@ description: 'Run Sonatype Nancy as part of your GitHub Actions workflow.'
 inputs:
   goListFile:
     description: 'The path to a file containing the output of a "go list ..." command.'
-    required: true
+    required: false
+    default: go.list
   nancyCommand:
     description: 'Optional nancy command. Defaults to "sleuth"'
     required: false

--- a/action.yml
+++ b/action.yml
@@ -2,14 +2,19 @@ name: 'Nancy for GitHub Actions'
 author: 'Sonatype'
 description: 'Run Sonatype Nancy as part of your GitHub Actions workflow.'
 inputs:
-  target:
-    description: 'This is the path to the go.sum or Gopkg.lock file.'
+  goListFile:
+    description: 'The path to a file containing the output of a "go list ..." command.'
     required: true
+  nancyCommand:
+    description: 'Optional nancy command. Defaults to "sleuth"'
+    required: false
+    default: 'sleuth'
 runs:
   using: 'docker'
   image: 'Dockerfile'
   args:
-    - ${{ inputs.target }}
+    - ${{ inputs.goListFile }}
+    - ${{ inputs.nancyCommand }}
 branding:
   icon: 'shield'
   color: 'gray-dark'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,12 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-pwd
-cd $GITHUB_WORKSPACE
-pwd
-
 export GOROOT=/usr/local/go/
 export PATH=$PATH:$GOROOT/bin
 
-#/usr/local/nancy $1
-/usr/local/go/bin/go list -json -m all | nancy $1
+nancy $2 < $1

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,5 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cd $GITHUB_WORKSPACE
-/usr/local/nancy $1
+#cd $GITHUB_WORKSPACE
+#/usr/local/nancy $1
+$1

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,7 +14,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-export GOROOT=/usr/local/go/
-export PATH=$PATH:$GOROOT/bin
-
 nancy $2 < $1

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -16,4 +16,4 @@
 
 #cd $GITHUB_WORKSPACE
 #/usr/local/nancy $1
-$1
+go list -json -m all | /nancy $1

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -17,5 +17,9 @@
 pwd
 cd $GITHUB_WORKSPACE
 pwd
+
+export GOROOT=/usr/local/go/
+export PATH=$PATH:$GOROOT/bin
+
 #/usr/local/nancy $1
 /usr/local/go/bin/go list -json -m all | nancy $1

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,4 +14,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-/usr/local/nancy $GITHUB_WORKSPACE/$1
+cd $GITHUB_WORKSPACE
+/usr/local/nancy $1

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#cd $GITHUB_WORKSPACE
+pwd
+cd $GITHUB_WORKSPACE
+pwd
 #/usr/local/nancy $1
-go list -json -m all | /nancy $1
+/usr/local/go/bin/go list -json -m all | nancy $1


### PR DESCRIPTION
Changes the github action to use Nancy v1.0.0.

* use .apk to install nancy in docker image.
* read `go.list` file which contains the output of `go list` command

Also adds some development notes.