### PR TITLE
Use latest nancy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ LABEL com.github.actions.name="Nancy for GitHub Actions" \
 RUN apk add --no-cache curl
 # required to get grep that supports -P option
 RUN apk add --no-cache --upgrade grep
-RUN desiredVersion="${NANCY_VERSION}" \
+RUN desiredVersion="${INPUT_NANCYVERSION}" \
     echo "desiredVersion: ${desiredVersion}" \
     if [[ ${desiredVersion} == "latest" ]] then \
       latest_version_is=$(curl --fail -s https://api.github.com/repos/sonatype-nexus-community/nancy/releases/latest | grep -oP '"tag_name": "\K(.*)(?=")') \

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ FROM alpine:3.12
 LABEL com.github.actions.name="Nancy for GitHub Actions" \
     com.github.actions.description="Run Sonatype Nancy as part of your GitHub Actions workflow."
 
+# required to fetch nancy.apk via curl
 RUN apk add --no-cache curl
 
 # required to get grep that supports -P option

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,6 @@ RUN apk add --no-cache --upgrade grep
 RUN apk add --no-cache --upgrade bash
 
 COPY install-nancy.sh /install-nancy.sh
-RUN ./install-nancy.sh $INPUT_NANCYVERSION
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,9 @@ RUN apk add --no-cache curl
 # required to get grep that supports -P option
 RUN apk add --no-cache --upgrade grep
 
+# required to bash for install script
+RUN apk add --no-cache --upgrade bash
+
 COPY install-nancy.sh /install-nancy.sh
 RUN ./install-nancy.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,9 +22,6 @@ RUN apk add --no-cache curl
 # required to get grep that supports -P option
 RUN apk add --no-cache --upgrade grep
 
-# required to bash for install script
-RUN apk add --no-cache --upgrade bash
-
 COPY install-nancy.sh /install-nancy.sh
 
 COPY entrypoint.sh /entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN apk add --no-cache --upgrade grep
 RUN apk add --no-cache --upgrade bash
 
 COPY install-nancy.sh /install-nancy.sh
-RUN ./install-nancy.sh
+RUN ./install-nancy.sh $INPUT_NANCYVERSION
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,18 +18,12 @@ LABEL com.github.actions.name="Nancy for GitHub Actions" \
     com.github.actions.description="Run Sonatype Nancy as part of your GitHub Actions workflow."
 
 RUN apk add --no-cache curl
+
 # required to get grep that supports -P option
 RUN apk add --no-cache --upgrade grep
-RUN desiredVersion="${INPUT_NANCYVERSION}" \
-    echo "desiredVersion: ${desiredVersion}" \
-    if [[ ${desiredVersion} == "latest" ]] then \
-      latest_version_is=$(curl --fail -s https://api.github.com/repos/sonatype-nexus-community/nancy/releases/latest | grep -oP '"tag_name": "\K(.*)(?=")') \
-      desiredVersion=${latest_version_is} \
-    fi \
-    sourceUrl="https://github.com/sonatype-nexus-community/nancy/releases/download/${desiredVersion}/nancy-${desiredVersion}-linux_386.apk" \
-    echo "installing nancy via ${sourceUrl}" \
-    curl -L -o nancy.apk ${sourceUrl} \
-    apk add --no-cache --allow-untrusted nancy.apk
+
+COPY install-nancy.sh /install-nancy.sh
+RUN ./install-nancy.sh
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:3.12
+FROM alpine:3.13
 
 LABEL com.github.actions.name="Nancy for GitHub Actions" \
     com.github.actions.description="Run Sonatype Nancy as part of your GitHub Actions workflow."

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,10 +17,18 @@ FROM alpine:3.12
 LABEL com.github.actions.name="Nancy for GitHub Actions" \
     com.github.actions.description="Run Sonatype Nancy as part of your GitHub Actions workflow."
 
-RUN apk add --no-cache curl && \
-    echo "NANCY_VERSION: $NANCY_VERSION" && \
-    curl -L -o nancy.apk \
-        https://github.com/sonatype-nexus-community/nancy/releases/download/v1.0.0/nancy_1.0.0_linux_386.apk && \
+RUN apk add --no-cache curl
+# required to get grep that supports -P option
+RUN apk add --no-cache --upgrade grep
+RUN desiredVersion="${NANCY_VERSION}" \
+    echo "desiredVersion: ${desiredVersion}" \
+    if [[ ${desiredVersion} == "latest" ]] then \
+      latest_version_is=$(curl --fail -s https://api.github.com/repos/sonatype-nexus-community/nancy/releases/latest | grep -oP '"tag_name": "\K(.*)(?=")') \
+      desiredVersion=${latest_version_is} \
+    fi \
+    sourceUrl="https://github.com/sonatype-nexus-community/nancy/releases/download/${desiredVersion}/nancy-${desiredVersion}-linux_386.apk" \
+    echo "installing nancy via ${sourceUrl}" \
+    curl -L -o nancy.apk ${sourceUrl} \
     apk add --no-cache --allow-untrusted nancy.apk
 
 COPY entrypoint.sh /entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ LABEL com.github.actions.name="Nancy for GitHub Actions" \
     com.github.actions.description="Run Sonatype Nancy as part of your GitHub Actions workflow."
 
 RUN apk add --no-cache curl && \
+    echo "NANCY_VERSION: $NANCY_VERSION" && \
     curl -L -o nancy.apk \
         https://github.com/sonatype-nexus-community/nancy/releases/download/v1.0.0/nancy_1.0.0_linux_386.apk && \
     apk add --no-cache --allow-untrusted nancy.apk

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ For example: `sleuth --loud`
 
 The example below only requires `go` be installed in order to generate the `go.list` file. 
 You could instead have some other part of the CI build generate that file for use by `nancy`.
-```
+```yaml
 name: Go Nancy
 
 on: [push]
@@ -54,6 +54,13 @@ jobs:
       uses: sonatype-nexus-community/nancy-github-action@main
 ```
 
+The snippet below shows how to use a specific version of Nancy (rather than the latest)
+```yaml
+    - name: Scan with specific Nancy version
+      uses: sonatype-nexus-community/nancy-github-action@use_latest_nancy
+      with:
+        nancyVersion: "v1.0.6"
+```
 ## Development
 
 I found it useful to leverage the [act](https://github.com/nektos/act) project while developing
@@ -62,7 +69,7 @@ of that branch. For example, a [test project](https://github.com/bhamail/nancy-g
 Notice the commit hash `950a8965cd37d8e14aaa6aebd6c0d71b4da71fa3` used below in the `Scan` step to run the 
 development branch. 
 
-```
+```yaml
 name: Go
 
 on:

--- a/action.yml
+++ b/action.yml
@@ -3,7 +3,7 @@ author: 'Sonatype'
 description: 'Run Sonatype Nancy as part of your GitHub Actions workflow.'
 inputs:
   nancyVersion:
-    description: 'The version of Nancy to run. Example: v1.0.15 See: https://github.com/sonatype-nexus-community/nancy/releases for available versions.'
+    description: 'The version of Nancy to run. Examples: "latest", "v1.0.15" See: https://github.com/sonatype-nexus-community/nancy/releases for available versions.'
     required: true
     default: 'latest'
   goListFile:

--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ runs:
   using: 'docker'
   image: 'Dockerfile'
   env:
-    NANCY_VERSION: ${{ inputs.nancyVersion }}
+    NANCY_VERSION: inputs.nancyVersion
   args:
     - ${{ inputs.goListFile }}
     - ${{ inputs.nancyCommand }}

--- a/action.yml
+++ b/action.yml
@@ -3,7 +3,7 @@ author: 'Sonatype'
 description: 'Run Sonatype Nancy as part of your GitHub Actions workflow.'
 inputs:
   nancyVersion:
-    description: 'The version of Nancy to run. See: https://github.com/sonatype-nexus-community/nancy/releases for available versions.'
+    description: 'The version of Nancy to run. Example: v1.0.15 See: https://github.com/sonatype-nexus-community/nancy/releases for available versions.'
     required: true
     default: 'latest'
   goListFile:
@@ -17,8 +17,6 @@ inputs:
 runs:
   using: 'docker'
   image: 'Dockerfile'
-#  env:
-#    NANCY_VERSION: $inputs.nancyVersion
   args:
     - ${{ inputs.goListFile }}
     - ${{ inputs.nancyCommand }}

--- a/action.yml
+++ b/action.yml
@@ -17,8 +17,8 @@ inputs:
 runs:
   using: 'docker'
   image: 'Dockerfile'
-  env:
-    NANCY_VERSION: inputs.nancyVersion
+#  env:
+#    NANCY_VERSION: $inputs.nancyVersion
   args:
     - ${{ inputs.goListFile }}
     - ${{ inputs.nancyCommand }}

--- a/action.yml
+++ b/action.yml
@@ -2,6 +2,10 @@ name: 'Nancy for GitHub Actions'
 author: 'Sonatype'
 description: 'Run Sonatype Nancy as part of your GitHub Actions workflow.'
 inputs:
+  nancyVersion:
+    description: 'The version of Nancy to run. See: https://github.com/sonatype-nexus-community/nancy/releases for available versions.'
+    required: true
+    default: 'latest'
   goListFile:
     description: 'The path to a file containing the output of a "go list ..." command.'
     required: false
@@ -13,6 +17,8 @@ inputs:
 runs:
   using: 'docker'
   image: 'Dockerfile'
+  env:
+    NANCY_VERSION: ${{ inputs.nancyVersion }}
   args:
     - ${{ inputs.goListFile }}
     - ${{ inputs.nancyCommand }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -20,6 +20,6 @@ echo "entrypoint INPUT_NANCYVERSION: ${INPUT_NANCYVERSION}"
 pwd
 ls -alh
 ls -alh /
-./install-nancy.sh $INPUT_NANCYVERSION
+/install-nancy.sh $INPUT_NANCYVERSION
 
 nancy $2 < $1

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,4 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+echo "entrypoint NANCY_VERSION: ${NANCY_VERSION}"
+
 nancy $2 < $1

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,5 +15,6 @@
 # limitations under the License.
 
 echo "entrypoint NANCY_VERSION: ${NANCY_VERSION}"
+echo "entrypoint INPUT_NANCYVERSION: ${INPUT_NANCYVERSION}"
 
 nancy $2 < $1

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -19,6 +19,7 @@ echo "entrypoint INPUT_NANCYVERSION: ${INPUT_NANCYVERSION}"
 
 pwd
 ls -alh
+ls -alh /
 ./install-nancy.sh $INPUT_NANCYVERSION
 
 nancy $2 < $1

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -17,6 +17,8 @@
 echo "entrypoint NANCY_VERSION: ${NANCY_VERSION}"
 echo "entrypoint INPUT_NANCYVERSION: ${INPUT_NANCYVERSION}"
 
+pwd
+ls -alh
 ./install-nancy.sh $INPUT_NANCYVERSION
 
 nancy $2 < $1

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# INPUT_NANCYVERSION env var is set automagically to the value of inputs.nancyVersion
 /install-nancy.sh $INPUT_NANCYVERSION
 
 nancy $2 < $1

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,12 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-echo "entrypoint NANCY_VERSION: ${NANCY_VERSION}"
-echo "entrypoint INPUT_NANCYVERSION: ${INPUT_NANCYVERSION}"
-
-pwd
-ls -alh
-ls -alh /
 /install-nancy.sh $INPUT_NANCYVERSION
 
 nancy $2 < $1

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -17,4 +17,6 @@
 echo "entrypoint NANCY_VERSION: ${NANCY_VERSION}"
 echo "entrypoint INPUT_NANCYVERSION: ${INPUT_NANCYVERSION}"
 
+./install-nancy.sh $INPUT_NANCYVERSION
+
 nancy $2 < $1

--- a/install-nancy.sh
+++ b/install-nancy.sh
@@ -1,3 +1,5 @@
+#!/bin/ash
+
 # Copyright (c) 2019-present Sonatype, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/install-nancy.sh
+++ b/install-nancy.sh
@@ -30,4 +30,4 @@ fi
 sourceUrl="https://github.com/sonatype-nexus-community/nancy/releases/download/${desiredVersion}/nancy_${desiredVersion:1}_linux_386.apk"
 echo "installing nancy via ${sourceUrl}"
 curl --fail -L -o nancy.apk ${sourceUrl}
-apk add --no-cache --quiet --allow-untrusted nancy.apk
+apk add --quiet --allow-untrusted nancy.apk

--- a/install-nancy.sh
+++ b/install-nancy.sh
@@ -1,5 +1,3 @@
-#!/bin/sh
-
 # Copyright (c) 2019-present Sonatype, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/install-nancy.sh
+++ b/install-nancy.sh
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/sh
 
 # Copyright (c) 2019-present Sonatype, Inc.
 #

--- a/install-nancy.sh
+++ b/install-nancy.sh
@@ -14,10 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-desiredVersion="${INPUT_NANCYVERSION}"
+desiredVersion="$1"
 echo "desiredVersion: ${desiredVersion}"
 if [ -z "$desiredVersion" ]; then
-  >&2 echo "missing environment variable: INPUT_NANCYVERSION"
+  >&2 echo "must specify a desiredVersion"
   exit 1
 fi
 if [[ ${desiredVersion} == "latest" ]]; then

--- a/install-nancy.sh
+++ b/install-nancy.sh
@@ -30,4 +30,4 @@ fi
 sourceUrl="https://github.com/sonatype-nexus-community/nancy/releases/download/${desiredVersion}/nancy_${desiredVersion:1}_linux_386.apk"
 echo "installing nancy via ${sourceUrl}"
 curl --fail -L -o nancy.apk ${sourceUrl}
-apk add --quiet --allow-untrusted nancy.apk
+apk add --no-progress --quiet --no-cache --allow-untrusted nancy.apk

--- a/install-nancy.sh
+++ b/install-nancy.sh
@@ -17,14 +17,14 @@
 desiredVersion="$1"
 echo "desiredVersion: ${desiredVersion}"
 if [ -z "$desiredVersion" ]; then
-  >&2 echo "must specify a desiredVersion"
+  >&2 echo "must specify a desiredVersion, like: latest or v1.0.15"
   exit 1
 fi
 if [[ ${desiredVersion} == "latest" ]]; then
   latest_version_is=$(curl --fail -s https://api.github.com/repos/sonatype-nexus-community/nancy/releases/latest | grep -oP '"tag_name": "\K(.*)(?=")')
   desiredVersion=${latest_version_is}
 fi
-sourceUrl="https://github.com/sonatype-nexus-community/nancy/releases/download/v${desiredVersion}/nancy_${desiredVersion}_linux_386.apk"
+sourceUrl="https://github.com/sonatype-nexus-community/nancy/releases/download/${desiredVersion}/nancy_${desiredVersion:1}_linux_386.apk"
 echo "installing nancy via ${sourceUrl}"
 curl --fail -L -o nancy.apk ${sourceUrl}
 apk add --no-cache --allow-untrusted nancy.apk

--- a/install-nancy.sh
+++ b/install-nancy.sh
@@ -27,7 +27,7 @@ elif [[ ${desiredVersion:0:1} != "v" ]]; then
   exit 1
 fi
 # installer filename excludes v from version
-sourceUrl="https://github.com/sonatype-nexus-community/nancy/releases/download/${desiredVersion}/nancy_${desiredVersion:1}_linux_386.apk"
+sourceUrl="https://github.com/sonatype-nexus-community/nancy/releases/download/${desiredVersion}/nancy_${desiredVersion:1}_linux_amd64.apk"
 echo "installing nancy via ${sourceUrl}"
 curl --fail -L -o nancy.apk ${sourceUrl}
 apk add --no-progress --quiet --no-cache --allow-untrusted nancy.apk

--- a/install-nancy.sh
+++ b/install-nancy.sh
@@ -30,4 +30,4 @@ fi
 sourceUrl="https://github.com/sonatype-nexus-community/nancy/releases/download/${desiredVersion}/nancy_${desiredVersion:1}_linux_386.apk"
 echo "installing nancy via ${sourceUrl}"
 curl --fail -L -o nancy.apk ${sourceUrl}
-apk add --no-progress --quiet --allow-untrusted nancy.apk
+apk add --no-progress --quiet --no-cache --allow-untrusted nancy.apk

--- a/install-nancy.sh
+++ b/install-nancy.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 desiredVersion="$1"
-echo "desiredVersion: ${desiredVersion}"
+echo "desired nancy version: ${desiredVersion}"
 if [ -z "$desiredVersion" ]; then
   >&2 echo "must specify a desiredVersion, like: latest or v1.0.15"
   exit 1

--- a/install-nancy.sh
+++ b/install-nancy.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+# Copyright (c) 2019-present Sonatype, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+desiredVersion="${INPUT_NANCYVERSION}"
+echo "desiredVersion: ${desiredVersion}"
+if [[ ${desiredVersion} == "latest" ]]; then
+  latest_version_is=$(curl --fail -s https://api.github.com/repos/sonatype-nexus-community/nancy/releases/latest | grep -oP '"tag_name": "\K(.*)(?=")')
+  desiredVersion=${latest_version_is}
+fi
+sourceUrl="https://github.com/sonatype-nexus-community/nancy/releases/download/v${desiredVersion}/nancy_${desiredVersion}_linux_386.apk"
+echo "installing nancy via ${sourceUrl}"
+curl --fail -L -o nancy.apk ${sourceUrl}
+apk add --no-cache --allow-untrusted nancy.apk

--- a/install-nancy.sh
+++ b/install-nancy.sh
@@ -30,4 +30,4 @@ fi
 sourceUrl="https://github.com/sonatype-nexus-community/nancy/releases/download/${desiredVersion}/nancy_${desiredVersion:1}_linux_386.apk"
 echo "installing nancy via ${sourceUrl}"
 curl --fail -L -o nancy.apk ${sourceUrl}
-apk add --no-progress --quiet --no-cache --allow-untrusted nancy.apk
+apk add --no-progress --quiet --allow-untrusted nancy.apk

--- a/install-nancy.sh
+++ b/install-nancy.sh
@@ -30,4 +30,4 @@ fi
 sourceUrl="https://github.com/sonatype-nexus-community/nancy/releases/download/${desiredVersion}/nancy_${desiredVersion:1}_linux_386.apk"
 echo "installing nancy via ${sourceUrl}"
 curl --fail -L -o nancy.apk ${sourceUrl}
-apk add --no-cache --allow-untrusted nancy.apk
+apk add --no-cache --quiet --allow-untrusted nancy.apk

--- a/install-nancy.sh
+++ b/install-nancy.sh
@@ -19,11 +19,14 @@ echo "desiredVersion: ${desiredVersion}"
 if [ -z "$desiredVersion" ]; then
   >&2 echo "must specify a desiredVersion, like: latest or v1.0.15"
   exit 1
-fi
-if [[ ${desiredVersion} == "latest" ]]; then
+elif [[ ${desiredVersion} == "latest" ]]; then
   latest_version_is=$(curl --fail -s https://api.github.com/repos/sonatype-nexus-community/nancy/releases/latest | grep -oP '"tag_name": "\K(.*)(?=")')
   desiredVersion=${latest_version_is}
+elif [[ $desiredVersion != v* ]]; then
+  >&2 echo "specific version must start with v, like: v1.0.15"
+  exit 1
 fi
+# installer filename excludes v from version
 sourceUrl="https://github.com/sonatype-nexus-community/nancy/releases/download/${desiredVersion}/nancy_${desiredVersion:1}_linux_386.apk"
 echo "installing nancy via ${sourceUrl}"
 curl --fail -L -o nancy.apk ${sourceUrl}

--- a/install-nancy.sh
+++ b/install-nancy.sh
@@ -16,6 +16,10 @@
 
 desiredVersion="${INPUT_NANCYVERSION}"
 echo "desiredVersion: ${desiredVersion}"
+if [ -z "$desiredVersion" ]; then
+  >&2 echo "missing environment variable: INPUT_NANCYVERSION"
+  exit 1
+fi
 if [[ ${desiredVersion} == "latest" ]]; then
   latest_version_is=$(curl --fail -s https://api.github.com/repos/sonatype-nexus-community/nancy/releases/latest | grep -oP '"tag_name": "\K(.*)(?=")')
   desiredVersion=${latest_version_is}

--- a/install-nancy.sh
+++ b/install-nancy.sh
@@ -22,8 +22,8 @@ if [ -z "$desiredVersion" ]; then
 elif [[ ${desiredVersion} == "latest" ]]; then
   latest_version_is=$(curl --fail -s https://api.github.com/repos/sonatype-nexus-community/nancy/releases/latest | grep -oP '"tag_name": "\K(.*)(?=")')
   desiredVersion=${latest_version_is}
-elif [[ $desiredVersion != v* ]]; then
-  >&2 echo "specific version must start with v, like: v1.0.15"
+elif [[ ${desiredVersion:0:1} != "v" ]]; then
+  >&2 echo "specific nancy version (${desiredVersion}) must start with v, like: v1.0.15"
   exit 1
 fi
 # installer filename excludes v from version


### PR DESCRIPTION
This PR adds a new configuration option: `nancyVersion`.
Valid values for this option are 'latest' or a specific version, like `v.1.0.6'.
Default value is 'latest'.

I chose to use a call to the github api to determine the latest version for a few reasons:
* I have bad memories of "un-versioned" jar names for the days of java/maven
* I like being able to easily "log" the download url showing exactly which version we're using.

Fixes issue #3 