### PR TITLE
feat: authenticate github API calls

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,10 @@ inputs:
     description: 'Optional nancy command. Defaults to "sleuth"'
     required: false
     default: 'sleuth'
+  githubToken:
+    description: 'Optional GitHub token. If not provided, no GitHub token will be used.'
+    required: false
+    default: ''
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/install-nancy.sh
+++ b/install-nancy.sh
@@ -14,13 +14,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+acurl() {
+  curl "$@"
+}
+if [ -n "${INPUT_GITHUBTOKEN}" ]; then
+  acurl() {
+    echo "using authenticated curl"
+    curl -H "Authorization: Bearer ${INPUT_GITHUBTOKEN}" "$@"
+  }
+fi
+
 desiredVersion="$1"
 echo "desired nancy version: ${desiredVersion}"
 if [ -z "$desiredVersion" ]; then
   >&2 echo "must specify a desiredVersion, like: latest or v1.0.15"
   exit 1
 elif [[ ${desiredVersion} == "latest" ]]; then
-  latest_version_is=$(curl --fail -s https://api.github.com/repos/sonatype-nexus-community/nancy/releases/latest | grep -oP '"tag_name": "\K(.*)(?=")')
+  latest_version_is=$(acurl --fail -s https://api.github.com/repos/sonatype-nexus-community/nancy/releases/latest | grep -oP '"tag_name": "\K(.*)(?=")')
   desiredVersion=${latest_version_is}
 elif [[ ${desiredVersion:0:1} != "v" ]]; then
   >&2 echo "specific nancy version (${desiredVersion}) must start with v, like: v1.0.15"
@@ -29,5 +39,5 @@ fi
 # installer filename excludes v from version
 sourceUrl="https://github.com/sonatype-nexus-community/nancy/releases/download/${desiredVersion}/nancy_${desiredVersion:1}_linux_amd64.apk"
 echo "installing nancy via ${sourceUrl}"
-curl --fail -L -o nancy.apk ${sourceUrl}
+acurl --fail -L -o nancy.apk "${sourceUrl}"
 apk add --no-progress --quiet --no-cache --allow-untrusted nancy.apk


### PR DESCRIPTION
We run into github ratelimits quite frequently with this action. This patch allows to pass the github workflow token to the action so that requests are authenticated and have higher rate-limits.

See this in action:
- working authenticated run: https://github.com/ory/keto/actions/runs/4165449080/jobs/7208469842#step:7:11
```
Run zepatrik/nancy-github-action@3b0a989791377b50913568102c0ed5539e4eb29c
/usr/bin/docker run --name c931338dfaed442b4bb0e891231e32862_6aeb52 --label 49859c --workdir /github/workspace --rm -e "INPUT_GITHUBTOKEN" -e "INPUT_NANCYVERSION" -e "INPUT_GOLISTFILE" -e "INPUT_NANCYCOMMAND" -e "HOME" -e "GITHUB_JOB" -e "GITHUB_REF" -e "GITHUB_SHA" -e "GITHUB_REPOSITORY" -e "GITHUB_REPOSITORY_OWNER" -e "GITHUB_REPOSITORY_OWNER_ID" -e "GITHUB_RUN_ID" -e "GITHUB_RUN_NUMBER" -e "GITHUB_RETENTION_DAYS" -e "GITHUB_RUN_ATTEMPT" -e "GITHUB_REPOSITORY_ID" -e "GITHUB_ACTOR_ID" -e "GITHUB_ACTOR" -e "GITHUB_TRIGGERING_ACTOR" -e "GITHUB_WORKFLOW" -e "GITHUB_HEAD_REF" -e "GITHUB_BASE_REF" -e "GITHUB_EVENT_NAME" -e "GITHUB_SERVER_URL" -e "GITHUB_API_URL" -e "GITHUB_GRAPHQL_URL" -e "GITHUB_REF_NAME" -e "GITHUB_REF_PROTECTED" -e "GITHUB_REF_TYPE" -e "GITHUB_WORKFLOW_REF" -e "GITHUB_WORKFLOW_SHA" -e "GITHUB_WORKSPACE" -e "GITHUB_ACTION" -e "GITHUB_EVENT_PATH" -e "GITHUB_ACTION_REPOSITORY" -e "GITHUB_ACTION_REF" -e "GITHUB_PATH" -e "GITHUB_ENV" -e "GITHUB_STEP_SUMMARY" -e "GITHUB_STATE" -e "GITHUB_OUTPUT" -e "RUNNER_OS" -e "RUNNER_ARCH" -e "RUNNER_NAME" -e "RUNNER_TOOL_CACHE" -e "RUNNER_TEMP" -e "RUNNER_WORKSPACE" -e "ACTIONS_RUNTIME_URL" -e "ACTIONS_RUNTIME_TOKEN" -e "ACTIONS_CACHE_URL" -e GITHUB_ACTIONS=true -e CI=true -v "/var/run/docker.sock":"/var/run/docker.sock" -v "/home/runner/work/_temp/_github_home":"/github/home" -v "/home/runner/work/_temp/_github_workflow":"/github/workflow" -v "/home/runner/work/_temp/_runner_file_commands":"/github/file_commands" -v "/home/runner/work/keto/keto":"/github/workspace" 49859c:931338dfaed442b4bb0e891231e32862  "go.list" "sleuth"
desired nancy version: latest
installing nancy via https://github.com/sonatype-nexus-community/nancy/releases/download/v1.0.42/nancy_1.0.42_linux_amd64.apk
using authenticated curl
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0

 12 5287k   12  655k    0     0   663k      0  0:00:07 --:--:--  0:00:07  663k
100 5287k  100 5287k    0     0  3915k      0  0:00:01  0:00:01 --:--:-- 12.4M
```

- failing (rate-limited) run: https://github.com/ory/keto/actions/runs/4164236213/jobs/7205620313#step:7:16
```
Run sonatype-nexus-community/nancy-github-action@v1.0.2
/usr/bin/docker run --name cbf33ca01a5964e4fa12ce2010bfd3f01_882bbe --label 49859c --workdir /github/workspace --rm -e "INPUT_NANCYVERSION" -e "INPUT_GOLISTFILE" -e "INPUT_NANCYCOMMAND" -e "HOME" -e "GITHUB_JOB" -e "GITHUB_REF" -e "GITHUB_SHA" -e "GITHUB_REPOSITORY" -e "GITHUB_REPOSITORY_OWNER" -e "GITHUB_REPOSITORY_OWNER_ID" -e "GITHUB_RUN_ID" -e "GITHUB_RUN_NUMBER" -e "GITHUB_RETENTION_DAYS" -e "GITHUB_RUN_ATTEMPT" -e "GITHUB_REPOSITORY_ID" -e "GITHUB_ACTOR_ID" -e "GITHUB_ACTOR" -e "GITHUB_TRIGGERING_ACTOR" -e "GITHUB_WORKFLOW" -e "GITHUB_HEAD_REF" -e "GITHUB_BASE_REF" -e "GITHUB_EVENT_NAME" -e "GITHUB_SERVER_URL" -e "GITHUB_API_URL" -e "GITHUB_GRAPHQL_URL" -e "GITHUB_REF_NAME" -e "GITHUB_REF_PROTECTED" -e "GITHUB_REF_TYPE" -e "GITHUB_WORKFLOW_REF" -e "GITHUB_WORKFLOW_SHA" -e "GITHUB_WORKSPACE" -e "GITHUB_ACTION" -e "GITHUB_EVENT_PATH" -e "GITHUB_ACTION_REPOSITORY" -e "GITHUB_ACTION_REF" -e "GITHUB_PATH" -e "GITHUB_ENV" -e "GITHUB_STEP_SUMMARY" -e "GITHUB_STATE" -e "GITHUB_OUTPUT" -e "RUNNER_OS" -e "RUNNER_ARCH" -e "RUNNER_NAME" -e "RUNNER_TOOL_CACHE" -e "RUNNER_TEMP" -e "RUNNER_WORKSPACE" -e "ACTIONS_RUNTIME_URL" -e "ACTIONS_RUNTIME_TOKEN" -e "ACTIONS_CACHE_URL" -e GITHUB_ACTIONS=true -e CI=true -v "/var/run/docker.sock":"/var/run/docker.sock" -v "/home/runner/work/_temp/_github_home":"/github/home" -v "/home/runner/work/_temp/_github_workflow":"/github/workflow" -v "/home/runner/work/_temp/_runner_file_commands":"/github/file_commands" -v "/home/runner/work/keto/keto":"/github/workspace" 49859c:bf33ca01a5964e4fa12ce2010bfd3f01  "go.list" "sleuth"
desired nancy version: latest
installing nancy via https://github.com/sonatype-nexus-community/nancy/releases/download//nancy__linux_amd64.apk
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
curl: (22) The requested URL returned error: 404
ERROR: nancy.apk: No such file or directory
/entrypoint.sh: line 20: nancy: not found
```